### PR TITLE
商品出品、編集時にフォームバリデーションを追加

### DIFF
--- a/app/assets/stylesheets/modules/items.scss
+++ b/app/assets/stylesheets/modules/items.scss
@@ -18,6 +18,9 @@
     &__text {
       font-size: 15px;
       padding-bottom: 10px;
+      .color-red {
+        color: red;
+      }
     }
     &__upload {
       height: 170px;

--- a/app/javascript/items.js
+++ b/app/javascript/items.js
@@ -3,7 +3,7 @@ $(window).on('load', ()=> {
   function buildFileField(index) {
     const html = `<div class="file" data-index="${index}">
                     <input id="item_images_attributes_${index}_image_url" class="file__image" type="file"
-                    name="item[images_attributes][${index}][image_url]" data-index="${index}">
+                    name="item[images_attributes][${index}][image_url]" data-index="${index}" required="required">
                   </div>`;
     return html;
   }

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -9,7 +9,9 @@
             %span.exhibit__form-require
               必須
         .exhibit__image__text
-          最大5枚までアップロードできます
+          最大5枚までアップロードできます(
+          %span.color-red 必ず1枚は添付してください
+          )
         .exhibit__image__upload
           .previews
             - if @item.persisted?
@@ -29,7 +31,7 @@
                 
           - if @item.persisted?
             .file{"data-index" => "#{@item.images.count}"}
-              = file_field_tag :image_url, id: "item_images_attributes_#{@item.images.count}_image_url", name: "item[images_attributes][#{@item.images.count}][image_url]", class: 'file__image'
+              = file_field_tag :image_url, id: "item_images_attributes_#{@item.images.count}_image_url", name: "item[images_attributes][#{@item.images.count}][image_url]", class: 'file__image', required: true
 
 
           %label{for: "item_images_attributes_#{@item.images.length}_image_url", class: 'label'}
@@ -156,7 +158,7 @@
               ¥
             .exhibit__enter-price
               .exhibit__enter-price2
-                = f.number_field :price, placeholder: "0", class: "tk-price", required: true
+                = f.number_field :price, placeholder: "0", class: "tk-price", required: true, min:"300", max:"9999999"
                 .exhibit__no-product.no-product2
           .exhibit__commission
             .exhibit__commission-box

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -9,7 +9,9 @@
             %span.exhibit__form-require
               必須
         .exhibit__image__text
-          最大5枚までアップロードできます
+          最大5枚までアップロードできます(
+          %span.color-red 必ず1枚は添付してください
+          )
         .exhibit__image__upload
           .previews
             - if @item.persisted?
@@ -23,7 +25,7 @@
 
           = f.fields_for :images do |image|
             .file{"data-index" => "#{image.index}"}   
-              = image.file_field :image_url, class: 'file__image'
+              = image.file_field :image_url, class: 'file__image', required: true
           %label{for: "item_images_attributes_#{@item.images.length - 1}_image_url", class: 'label'}
             %i.fas.fa-camera.icon
 
@@ -138,7 +140,7 @@
               ¥
             .exhibit__enter-price
               .exhibit__enter-price2
-                = f.number_field :price, placeholder: "0", class: "tk-price", required: true
+                = f.number_field :price, placeholder: "0", class: "tk-price", required: true, min:"300", max:"9999999"
                 .exhibit__no-product.no-product2
           .exhibit__commission
             .exhibit__commission-box


### PR DESCRIPTION
# WHAT
 - 出品/編集時にブラウザで制約がかかるようにした
入力欄が空欄はNG、金額は300~9999999以内

# WHY
 - ユーザーユーティリティ向上のため