### PR TITLE
ニックネームの文字数制限

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  validates :nickname, presence: true
+  validates :nickname, presence: true, length: { minimum: 2, maximum: 10 }
   has_one :profile
   has_one :sending_destination
 


### PR DESCRIPTION
# WHAT 
 - ユーザーのnicknameの文字数に制限をかけた（２〜１０文字以内）

# WHY
 - 文字数に制限が無いと扱いづらいため。