### PR TITLE
マイページの見た目編集

### DIFF
--- a/app/views/users/_user_side.html.haml
+++ b/app/views/users/_user_side.html.haml
@@ -51,7 +51,7 @@
           = icon('fas','angle-right')
         %li.List-setting
           .List-setting__info
-            =link_to edit_user_path(current_user) do
+            =link_to "#" do
               .Card-branch
-                ログアウト
+                アカウント編集
           = icon('fas','angle-right')


### PR DESCRIPTION
# WHAT
マイページのサイドバーのログアウトボタンを削除し、アカウント編集ボタンに変えた（リンクは＃になっている）